### PR TITLE
Reset all font sizes relative to root element

### DIFF
--- a/client/src/assets/css/app.css
+++ b/client/src/assets/css/app.css
@@ -4836,6 +4836,7 @@ body {
     margin: 0;
     padding: 0;
     background: #f1f1f1;
+    font-size:1rem;
     font-family: Raleway, sans-serif;
     font-weight: 400;
     line-height: 1.5;


### PR DESCRIPTION
This will set a root font size. Future CSS adjustments will now be relative the root HTML element's font size.