### PR TITLE
Submission cancel modal

### DIFF
--- a/client/src/components/submit/Submit.jsx
+++ b/client/src/components/submit/Submit.jsx
@@ -92,7 +92,6 @@ class Submit extends Component {
             contentSaved: false,
             cancelSubmissionModal: false,
             redirect: false,
-            testing: false,
         }
 
         this.onOpenClick = this
@@ -397,8 +396,8 @@ class Submit extends Component {
             <div>
                 <HeadContainer history={this.props.history}/>
                 <Breadcrumbs title='Submit'/>
-                <Prompt key='block-nav' message='All the changes made will be lost, are you sure you want to leave?' when={this.state.contentSaved!==true}/>
 
+              {/* Modal window for preview button in the edit notebook submission */}
                 <Modal isOpen={this.state.modalOpen}
                        onRequestClose={this.closeModal}
                        contentLabel="Preview">
@@ -406,14 +405,16 @@ class Submit extends Component {
                     <NotebookPreview notebook={this.state.notebookJSON}/>
                 </Modal>
 
+                {/* Modal window for cancel button in the edit notebook submission */}
                 <Modal isOpen={this.state.cancelSubmissionModal}
                       onRequestClose={this.toggleCancelSubmissionModal}
                       contentLabel="Cancel Submission"
-                      style={customStyles}>
+                      style={customStyles}
+                      shouldCloseOnOverlayClick={false} >
                       <h3>All the changes made will be lost, are you sure you want to leave?</h3>
                         <ul className="button-row">
                           <li>
-                            <button className='invite-modal-button alt' onClick={this.closeModal}>Cancel</button>
+                            <button className='invite-modal-button alt' onClick={this.toggleCancelSubmissionModal}>Cancel</button>
                           </li>
                           <li>
                             {this.renderRedirect()}


### PR DESCRIPTION
Resolve issue  - client-side edit submission cancel notification #189

Below shows an implementation of the PR in replacement of alert/prompt box:
<img width="1055" alt="screen shot 2018-08-23 at 3 22 07 pm" src="https://user-images.githubusercontent.com/24495101/44506662-c6a41400-a6ea-11e8-9eb1-0c00ad773c4b.png">

When users click on **Cancel**, it will go back the current notebook submission and **Yes** will redirect users back to home page.

`shouldCloseOnOverlayClick={false}` has been implemented within the modal window so users cannot click anywhere outside of the modal.


