### PR TITLE
Signin page issues error when linked to externally #199

### DIFF
--- a/client/src/components/signin/SignIn.js
+++ b/client/src/components/signin/SignIn.js
@@ -72,17 +72,8 @@ class SignIn extends Component {
     render() {
         return (
             <div>
-                <HeadContainer history={this.props.history}/> {this.state.showErrorMessage
-                    ? <div className="warning callout">
-                            <div className="container">
-                                <p className="callout-message">
-                                    <ErrorIcon/>
-                                    An error occurred while trying to login
-                                </p>
-                            </div>
-                        </div>
-                    : null}
-                
+                <HeadContainer history={this.props.history}/> 
+
                 {this.props.loading
                 ? "loading..."
                 :<div className='modal'>


### PR DESCRIPTION
Removed the signing error message since users will the OAuth services including Twitter, FB, and Google will already check for signing errors.