### PR TITLE
Filter alignment CSS fix #225

### DIFF
--- a/client/src/assets/scss/src/layouts/listing.scss
+++ b/client/src/assets/scss/src/layouts/listing.scss
@@ -3,6 +3,7 @@
 .filters {
     position: relative;
     display: flex;
+    padding: 0 1rem 1rem 1rem;
     .sort-inputs {
         flex:1;
     }
@@ -66,6 +67,7 @@
     .totals {
         display: inline-block;
         color: $color-light;
+        margin: 0;
     }
 }
 


### PR DESCRIPTION
Adjusting padding and margin around the listing filters so they are all inline and neatly nested.