### PR TITLE
Block images submissions 275

### DIFF
--- a/client/src/assets/css/main.css
+++ b/client/src/assets/css/main.css
@@ -2758,6 +2758,8 @@ button {
     border-radius: 5px; }
   .submit-form p.textarea-hint {
     color: #d84d0a; }
+  .submit-form span.notebook-summary-hint {
+    color: #d84d0a; }
   .submit-form .form-error {
     margin: 0.5rem 0; }
   .submit-form .page-title {

--- a/client/src/assets/scss/src/components/forms.scss
+++ b/client/src/assets/scss/src/components/forms.scss
@@ -84,7 +84,11 @@
     input, textarea, select {
         border-radius: 5px;
     }
+
     p.textarea-hint {
+      color: #d84d0a;
+    }
+    span.notebook-summary-hint {
       color: #d84d0a;
     }
     .form-error {

--- a/client/src/components/submit/Submit.jsx
+++ b/client/src/components/submit/Submit.jsx
@@ -748,7 +748,10 @@ class Submit extends Component {
                                             onKeyPress={this.state.triggerOnKeyPress ? this.summaryLimit: null}
                                             onPaste={this.state.pasteValue ? this.pasting : null}
                                             value = {this.state.summary}></textarea>
-                                      <p class="textarea-hint">The maximum word count for summary is 250 words.</p>
+                                      <ul>
+																				<li><span class="notebook-summary-hint">The maximum word count for summary is 250 words.</span></li>
+																				<li><span class="notebook-summary-hint">Images are disabled by default.</span></li>
+																			</ul>
                                       </TabPanel>
                                       <TabPanel>
                                         <MarkdownRender


### PR DESCRIPTION
Word count will not count any markdown images `![dog](dog.png)` for example 
and when user preview or submit with images, images will not render. 