### PR TITLE
FIX: Sorting to use `Date` by default

### DIFF
--- a/client/src/actions/submissionList.js
+++ b/client/src/actions/submissionList.js
@@ -16,7 +16,7 @@ export function requestSubmissionPreviews(searchParams = {
     author: '',
     keywords: '',
     page: 1,
-    sortBy: 'Discover'
+    sortBy: 'Date'
 }) {
     return {
         type: REQUEST_SUBMISSION_PREVIEWS,
@@ -75,7 +75,7 @@ export const fetchSubmissions = ({searchParams, forced}) => {
         author: '',
         keywords: '',
         page: 1,
-        sortBy: 'Discover'
+        sortBy: 'Date'
     }, searchParams)
     console.log('[Search] - search params: ', sp);
     return function (dispatch) {

--- a/client/src/components/searchbar/Searchbar.jsx
+++ b/client/src/components/searchbar/Searchbar.jsx
@@ -202,8 +202,8 @@ class Searchbar extends Component {
                                     onChange={this.sortByChanged}
                                     value={this.state.searchParams.sortBy}>
                                     <option value="Comments">Comments</option>
-                                    <option value="Date">Date</option>
-                                    <option value="Discover" selected>Discover</option>
+                                    <option value="Date" selected>Date</option>
+                                    <option value="Discover">Discover</option>
                                     <option value="Views">Views</option>
                                     <option value="Votes">Votes</option>
                                 </select>

--- a/client/src/containers/submission/SubmissionListContainer.jsx
+++ b/client/src/containers/submission/SubmissionListContainer.jsx
@@ -37,7 +37,7 @@ class SubmissionListContainer extends Component {
                         author: '',
                         keywords: '',
                         page: 1,
-                        sortBy: 'Discover'
+                        sortBy: 'Date'
                     }}
                     onPageChange={this.onPageChange}
                     authors={this.props.authors}
@@ -57,7 +57,7 @@ function mapStateToProps(state, props) {
             author: '',
             keywords: '',
             page: 1,
-            sortBy: 'Discover'
+            sortBy: 'Date'
         }
     } else {
         searchParams = Object.assign({}, {
@@ -67,7 +67,7 @@ function mapStateToProps(state, props) {
             author: '',
             keywords: '',
             page: 1,
-            sortBy: 'Discover'
+            sortBy: 'Date'
         }, state.submissionList.searchParams);
     }
     if (props.userID) {

--- a/client/src/reducers/SubmissionList.js
+++ b/client/src/reducers/SubmissionList.js
@@ -12,7 +12,7 @@ const defaultSearchParams = {
     author: '',
     keywords: '',
     page: 1,
-    sortBy: 'Discover'
+    sortBy: 'Date'
 }
 
 const SubmissionList = (state = {


### PR DESCRIPTION
fixes https://github.com/QuantEcon/Bookshelf/issues/363